### PR TITLE
use `randombytes` instead of `crypto`.randomBytes

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var crypto = require('crypto');
+var randomBytes = require('randombytes');
 
 var defineProperty = Object.defineProperty;
 function next() {
-  return "@@symbol:" + crypto.randomBytes(8).toString('hex');
+  return "@@symbol:" + randomBytes(8).toString('hex');
 }
 
 

--- a/package.json
+++ b/package.json
@@ -16,5 +16,8 @@
     "harmony"
   ],
   "author": "Sean McArthur <sean.monstar@gmail.com> (http://seanmonstar.com)",
-  "license": "MPLv2.0"
+  "license": "MPLv2.0",
+  "dependencies": {
+    "randombytes": "^2.0.3"
+  }
 }


### PR DESCRIPTION
hey @seanmonstar,

here's a simple pull request to use the [`randombytes`](https://github.com/crypto-browserify/randombytes) module directly instead of the built-in `crypto` module for `randomBytes`. in node, this will [be the same](https://github.com/crypto-browserify/randombytes/blob/master/index.js), but in the browser this will minimize dependencies to be only what's necessary (without this change, browserify or webpack embed the full [`crypto-browserify`](https://github.com/crypto-browserify/crypto-browserify) module, which relies on `randombytes` for `crypto.randomBytes`).

cheers!
